### PR TITLE
Processing - change base class so as to have less code in export_all algorithm

### DIFF
--- a/veloroutes_voies_vertes/processing/covadis/export_all.py
+++ b/veloroutes_voies_vertes/processing/covadis/export_all.py
@@ -3,32 +3,16 @@ __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 __revision__ = "$Format:%H$"
 
-from qgis.core import (
-    QgsProcessingParameterString,
-    QgsProcessingOutputMultipleLayers,
-    QgsProcessingParameterFolderDestination,
-    QgsProcessingParameterBoolean
-)
-
 import processing
-from ...qgis_plugin_tools.tools.algorithm_processing import BaseProcessingAlgorithm
+from .export_covadis import ExportCovadis
 from ...qgis_plugin_tools.tools.i18n import tr
 
 
-class ExportCovadisAll(BaseProcessingAlgorithm):
+class ExportCovadisAll(ExportCovadis):
     """
     Export des données dans le format d’échange shape d’ESRI
     conformement au standard Covadis
     """
-
-    DATABASE = "DATABASE"
-    SCHEMA = "SCHEMA"
-    TABLE = "TABLE"
-    DPT = "DPT"
-    OUTPUT = "OUTPUT"
-    OUTPUT_MSG = "OUTPUT_MSG"
-    PROJECTS_FOLDER="FOLDER"
-    CHARGER="CHARGER"
 
     def name(self):
         return "export_all_covadis"
@@ -36,75 +20,12 @@ class ExportCovadisAll(BaseProcessingAlgorithm):
     def displayName(self):
         return tr("Export de tous les fichiers")
 
-    def groupId(self):
-        return "covadis"
-
-    def group(self):
-        return tr("Covadis")
-
     def shortHelpString(self):
         return tr("Exporter tous les fichiers au format shape d'ESRI")
 
     def initAlgorithm(self, config):
-
-        # Base contenant la table
-        db_param = QgsProcessingParameterString(
-            self.DATABASE, tr("Connexion à la base de données")
-        )
-        db_param.setMetadata(
-            {
-                "widget_wrapper": {
-                    "class": "processing.gui.wrappers_postgis.ConnectionWidgetWrapper"
-                }
-            }
-        )
-        self.addParameter(db_param)
-
-        # Schema contenant la table
-        schema_param = QgsProcessingParameterString(
-            self.SCHEMA, tr("Schéma"), "veloroutes", False, False
-        )
-        schema_param.setMetadata(
-            {
-                "widget_wrapper": {
-                    "class": "processing.gui.wrappers_postgis.SchemaWidgetWrapper",
-                    "connection_param": self.DATABASE
-                }
-            }
-        )
-        self.addParameter(schema_param)
-
-        # Nom du département pour le fichier d'export
-        depparam= QgsProcessingParameterString(
-            self.DPT,
-            tr("Département au format XXX"),
-            '066',
-            optional=False
-        )
-        self.addParameter(depparam)
-
-        # Chemin du dossier de destination
-        outparam = QgsProcessingParameterFolderDestination(
-            self.PROJECTS_FOLDER,
-            tr("Chemin de destination"),
-            '',
-            False,
-            False
-        )
-        self.addParameter(outparam)
-
-        self.addParameter(
-            QgsProcessingParameterBoolean(
-                self.CHARGER,
-                tr("Charger les couches dans le projet"),
-                defaultValue=False,
-                optional=False,
-            )
-        )
-
-        self.addOutput(
-            QgsProcessingOutputMultipleLayers(self.OUTPUT, tr("Couches de sortie"))
-        )
+        super().initAlgorithm(config)
+        self.removeParameter('TABLE')
 
     def processAlgorithm(self, parameters, context, feedback):
         msg = ""


### PR DESCRIPTION
## Description

*  Processing - change base class so as to have less code in export_all algorithm

Use `ExportCovadis` as base class for the `ExportCovadisAll` algorithm, so parameters are all ready defined.

```
Algorithm 'Export de tous les fichiers' starting…
Input parameters:
{ 'CHARGER' : False, 'DATABASE' : 'Raepa', 'DPT' : '066', 'FOLDER' : '/tmp', 'SCHEMA' : 'veloroutes' }

## CONNEXION A LA BASE DE DONNEES ##

## CHARGEMENT DE LA COUCHE ##
Results: {'OUTPUT': 'itineraire_407ecf11_81c4_44e5_9fa4_e0d5da49a145', 'OUTPUT MSG': ''}
## CONNEXION A LA BASE DE DONNEES ##

## CHARGEMENT DE LA COUCHE ##
Results: {'OUTPUT': 'portion_3c4c3987_baee_4e82_84f2_04ee6b41e55b', 'OUTPUT MSG': ''}
## CONNEXION A LA BASE DE DONNEES ##

## CHARGEMENT DE LA COUCHE ##
Results: {'OUTPUT': 'element_c7b00af8_cbcc_4c6a_88b0_ff90cd50b06a', 'OUTPUT MSG': ''}
## CONNEXION A LA BASE DE DONNEES ##
...
```
