### PR TITLE
Check actions in QML on the CI

### DIFF
--- a/veloroutes_voies_vertes/actions.py
+++ b/veloroutes_voies_vertes/actions.py
@@ -309,3 +309,17 @@ def _add_relation(selected_features_id, rel_layer_name, feature_id, feature_rel,
         new_feature[feature_id] = item[1]
         layer.addFeature(new_feature)
     layer.commitChanges()
+
+
+# Dictionary of actions
+# number of arguments it expects
+# function to call
+# extra args to add on runtime
+actions = {
+    'split_segment':
+        [3, split_segment],
+    'update_selected_feature':
+        [3, update_selected_feature],
+    'create_relation':
+        [6, create_relation]
+}

--- a/veloroutes_voies_vertes/plugin.py
+++ b/veloroutes_voies_vertes/plugin.py
@@ -12,7 +12,7 @@ __revision__ = "$Format:%H$"
 from qgis.core import QgsApplication, QgsMessageLog, Qgis
 from qgis.PyQt.QtWidgets import QMessageBox
 
-from .actions import split_segment, update_selected_feature, create_relation
+from .actions import actions
 
 from .processing.provider import VeloroutesProvider
 
@@ -44,18 +44,6 @@ class VeloroutesPlugin:
         from qgis.utils import plugins
         plugins['veloroutes_voies_vertes'].run_action('action_name', params)
         """
-        # Dictionary of actions
-        # number of arguments it expects
-        # function to call
-        # extra args to add on runtime
-        actions = {
-            'split_segment':
-                [3, split_segment],
-            'update_selected_feature':
-                [3, update_selected_feature],
-            'create_relation':
-                [6, create_relation]
-        }
         if name not in actions:
             QMessageBox.critical(
                 None, 'Action non trouvée', 'L\'action n\'a pas été trouvée.')

--- a/veloroutes_voies_vertes/resources/qml/segment.qml
+++ b/veloroutes_voies_vertes/resources/qml/segment.qml
@@ -497,7 +497,7 @@
   <expressionfields/>
   <attributeactions>
     <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
-    <actionsetting type="1" name="Couper un segment en un point" capture="0" id="{adebc8b8-9bef-44df-b9d7-290193d85bc8}" shortTitle="split" notificationMessage="" isEnabledOnlyWhenEditable="1" action="from qgis.utils import plugins&#xa;plugins['veloroutes_voies_vertes'].run_action('split_segment', [%id_segment%],[% @click_x %],[% @click_y %])&#xa;print([%id_segment%])" icon="">
+    <actionsetting type="1" name="Couper un segment en un point" capture="0" id="{adebc8b8-9bef-44df-b9d7-290193d85bc8}" shortTitle="split" notificationMessage="" isEnabledOnlyWhenEditable="1" action="from qgis.utils import plugins&#xa;plugins['veloroutes_voies_vertes'].run_action('split_segment', [%id_segment%],[% @click_x %],[% @click_y %])" icon="">
       <actionScope id="Field"/>
       <actionScope id="Layer"/>
       <actionScope id="Feature"/>

--- a/veloroutes_voies_vertes/test/test_action_qml.py
+++ b/veloroutes_voies_vertes/test/test_action_qml.py
@@ -1,0 +1,64 @@
+__copyright__ = "Copyright 2020, 3Liz"
+__license__ = "GPL version 3"
+__email__ = "info@3liz.org"
+
+import os
+import unittest
+import re
+
+from qgis.PyQt.QtXml import QDomDocument
+
+from qgis_plugin_tools.tools.resources import resources_path
+
+from veloroutes_voies_vertes import actions
+
+PLUGIN_NAME = 'veloroutes_voies_vertes'
+REGEX = r"^from qgis\.utils import plugins\nplugins\['(\w*)'\].run_action\('(\w*)', (.*)\)$"
+
+
+class TestQmlAction(unittest.TestCase):
+
+    @staticmethod
+    def qml_files():
+        list_files = []
+        for root, _, files in os.walk(resources_path('qml')):
+            for file in files:
+                if file.lower().endswith('.qml'):
+                    file_path = os.path.join(root, file)
+                    list_files.append(file_path)
+        return list_files
+
+    def test_qml_action(self):
+        """Test that actions in QML exists in Python code. """
+
+        for qml in self.qml_files():
+            with open(qml, 'r') as qml_file:
+                content = qml_file.read()
+
+            dom = QDomDocument()
+            dom.setContent(content)
+            nodelist = dom.elementsByTagName("actionsetting")
+
+            for i in range(nodelist.count()):
+                node = nodelist.at(i).attributes()
+                python_action = node.namedItem('action').nodeValue()
+
+                matches = re.search(REGEX, python_action)
+                self.assertIsNotNone(matches, 'The action must match the regexp')
+
+                groups = matches.groups()
+
+                # The plugin name in the action must match
+                self.assertEqual(PLUGIN_NAME, groups[0], 'The plugin name must be {}'.format(PLUGIN_NAME))
+
+                # The name of the function must be correct
+                self.assertIn(
+                    groups[1],
+                    list(actions.actions.keys()),
+                    'The action {} is not defined in the plugin.'.format(groups[1]))
+
+                # Check number of arguments
+                self.assertEqual(
+                    actions.actions[groups[1]][0],
+                    len(groups[2].split(',')),
+                    'The number of parameters is not correct compare to the definition.')


### PR DESCRIPTION
Add a test to check actions stored in QML.

This test is checking : 
* The action matches a regexp pattern, strict
* Name of the Python function called in action, the action must exists in the plugin.
* Number of arguments given

The only thing not testable is the type of parameter (clicked X, clicked Y, strings, attributes etc).

The python code of the action itself is not covered by this test. This was already possible before, it just needs a test calling the Python function.

This code can be copy/pasted in another project.

For all actions which are not "edition only", we should use Python to create them. For instance in QuickOSM:

```python
    actions = layer.actions()

    title = tr('OpenStreetMap Browser')
    osm_browser = QgsAction(
        QgsAction.OpenUrl,
        title,
        'http://www.openstreetmap.org/browse/[% "osm_type" %]/[% "osm_id" %]',
        '',
        False,
        title,
        ACTIONS_VISIBILITY,
        ''
    )
    actions.addAction(osm_browser)
```

CC @drillinP @rldhont @mdouchin 


